### PR TITLE
 Since version 3, the molecule lint option is string.

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,4 @@
-lint:
-  name: 'yamllint -c tests/yamllint.yml .'
+lint: 'yamllint -c tests/yamllint.yml .'
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,7 +1,5 @@
 lint:
-  name: yamllint
-  options:
-    config-file: tests/yamllint.yml
+  name: 'yamllint -c tests/yamllint.yml .'
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
https://molecule.readthedocs.io/en/latest/configuration.html#lint