### PR TITLE
Since version 3, the molecule lint option is string. (#1)

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,7 +1,4 @@
-lint:
-  name: yamllint
-  options:
-    config-file: tests/yamllint.yml
+lint: 'yamllint -c tests/yamllint.yml .'
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
* Since version 3, the molecule lint option is string. https://molecule.readthedocs.io/en/latest/configuration.html#lint